### PR TITLE
Server/geojson data mode decouple

### DIFF
--- a/client/src/pages/Workspace/tabs/Transform/Export.jsx
+++ b/client/src/pages/Workspace/tabs/Transform/Export.jsx
@@ -39,14 +39,21 @@ const Export = () => {
 	}
 
 	const handleExport = async () => {
-		const formData = new FormData();
+        const formData = new FormData();
+        
+        const featureCollection = {
+            type: "FeatureCollection",
+            features: drawRef.current.getAll().features,
+        };
+        const blob = new Blob(
+            [JSON.stringify(featureCollection)],
+            { type: "application/geo+json" }
+        );
+        formData.append("input_file", blob, "input.geojson"); 
+
         const config = {
             input: {
                 format: "geojson",
-                data: {
-                    type: "FeatureCollection",
-                    features: drawRef.current.getAll().features
-                }
             },
             output: {
                 format: outputFormat,

--- a/client/src/pages/Workspace/tabs/Transform/Operations/BufferTransform.jsx
+++ b/client/src/pages/Workspace/tabs/Transform/Operations/BufferTransform.jsx
@@ -11,7 +11,7 @@ import { useTheme } from "@mui/material/styles"
 import { toast } from "react-toastify";
 import {StyledTextField, StyledSelect, StyledButton, StyledInputLabel} from "../../../../../utils/InputStyles";
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
-import { runGeoflipJob } from "../../../../../utils/geoflip-helper";
+import { runGeoflipJob, createGeojsonFile } from "../../../../../utils/geoflip-helper";
 
 const BufferTransform = ({setLoading}) => {
 	const theme = useTheme();
@@ -42,14 +42,20 @@ const BufferTransform = ({setLoading}) => {
 			setLoading(true);
             try {
                 const formData = new FormData();
+                
+                const featureCollection = {
+                    type: "FeatureCollection",
+                    features: drawRef.current.getAll().features,
+                };
+                const blob = new Blob(
+                    [JSON.stringify(featureCollection)],
+                    { type: "application/geo+json" }
+                );
+                formData.append("input_file", blob, "input.geojson"); 
 
                 const config = {
                     input: {
                         format: "geojson",
-                        data: {
-                            type: "FeatureCollection",
-                            features: drawRef.current.getAll().features
-                        }
                     },
                     transformations:[
                         {
@@ -61,10 +67,10 @@ const BufferTransform = ({setLoading}) => {
                         }
                     ],
                     output: {
-                        format: "geojson"
+                        format: "geojson",
+                        to_file: false
                     }
                 };
-
                 formData.append('config', JSON.stringify(config));
 
                 const geojsonData = await runGeoflipJob(

--- a/client/src/pages/Workspace/tabs/Transform/Operations/BufferTransform.jsx
+++ b/client/src/pages/Workspace/tabs/Transform/Operations/BufferTransform.jsx
@@ -11,7 +11,7 @@ import { useTheme } from "@mui/material/styles"
 import { toast } from "react-toastify";
 import {StyledTextField, StyledSelect, StyledButton, StyledInputLabel} from "../../../../../utils/InputStyles";
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
-import { runGeoflipJob, createGeojsonFile } from "../../../../../utils/geoflip-helper";
+import { runGeoflipJob } from "../../../../../utils/geoflip-helper";
 
 const BufferTransform = ({setLoading}) => {
 	const theme = useTheme();

--- a/client/src/pages/Workspace/tabs/Transform/Operations/UnionTransform.jsx
+++ b/client/src/pages/Workspace/tabs/Transform/Operations/UnionTransform.jsx
@@ -17,14 +17,20 @@ const UnionTransform = ({setLoading}) => {
 			setLoading(true);
             try {
                 const formData = new FormData();
+                
+                const featureCollection = {
+                    type: "FeatureCollection",
+                    features: drawRef.current.getAll().features,
+                };
+                const blob = new Blob(
+                    [JSON.stringify(featureCollection)],
+                    { type: "application/geo+json" }
+                );
+                formData.append("input_file", blob, "input.geojson"); 
 
                 const config = {
                     input: {
                         format: "geojson",
-                        data: {
-                            type: "FeatureCollection",
-                            features: drawRef.current.getAll().features
-                        }
                     },
                     transformations:[
                         {
@@ -35,7 +41,6 @@ const UnionTransform = ({setLoading}) => {
                         format: "geojson"
                     }
                 };
-
                 formData.append('config', JSON.stringify(config));
 
                 const geojsonData = await runGeoflipJob(

--- a/server/app/api/v1/operations/geoprocessing/writer.py
+++ b/server/app/api/v1/operations/geoprocessing/writer.py
@@ -123,7 +123,7 @@ def gdf_to_dxf(gdf: gpd.GeoDataFrame, output_dir: str, output_epsg: int) -> str:
     return output_path
 
 # returns the path to the output file or the content of the file
-def gdf_to_output(gdf: gpd.GeoDataFrame, output_format:str, output_epsg:int, job_id:str, to_file:bool = False) -> str:
+def gdf_to_output(gdf: gpd.GeoDataFrame, output_format:str, output_epsg:int, job_id:str, to_file:bool = True) -> str:
 	output_dir = os.path.join(app_config.DATA_PATH, job_id, "output")
 	os.makedirs(output_dir, exist_ok=True)
 	

--- a/server/app/api/v1/operations/transform.py
+++ b/server/app/api/v1/operations/transform.py
@@ -21,8 +21,7 @@ def transform_operation(self,
         output_epsg:int,
         input_epsg: Optional[int] = None, 
         input_file_path: str = None, 
-        data: dict = None,
-        to_file: bool = False
+        to_file: bool = True
     ) -> dict:
     input_gdf: gpd.GeoDataFrame = None
 
@@ -33,8 +32,8 @@ def transform_operation(self,
         self.update_state(state="PROGRESS", meta={"message": "Transform task started."})
 
         # Read input data
-        if (input_file_path or data) and not(input_file_path and data):
-            input_gdf = input_to_gdf(input_format, input_file_path, input_epsg, data)
+        if (input_file_path):
+            input_gdf = input_to_gdf(input_format, input_file_path, input_epsg)
             logger.info(f"Task {self.request.id}: Data read successfully {input_gdf.head()}")
         else:
             raise ValueError("Either input_file_path or data must be provided - not both.")

--- a/server/app/api/v1/routers/transform.py
+++ b/server/app/api/v1/routers/transform.py
@@ -43,7 +43,7 @@ async def create_transformation(
         raise HTTPException(status_code=400, detail="input is invalid")
     except Exception as e:
         logger.warning(f"Bad request: {e}")
-        raise HTTPException(status_code=400, detail=f"Bad request: {e}")
+        raise HTTPException(status_code=400, detail=f"Bad request {e}")
 
     input_format:str = transform.input.format
     input_epsg: int = transform.input.epsg


### PR DESCRIPTION
- updated api to no longer accept geojson data in text parts of the multipart form, all data must now be provided as a binary file
- updated client to package the maps geojson data into a binary file before sending to the api
- default for outputs is now always to_file = true, you can now also set this flag to false for geojson data only and it will return the geojson in the payload instead of a download URL but you have to explicitly set this